### PR TITLE
Refactoring default site folder references

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,3 +1,3 @@
 RewriteEngine on
-RewriteRule ^$ ../default/core/ [QSA,L]
-RewriteRule ^(.*)$ ../default/$1 [QSA,L]
+RewriteRule ^$ ../site-default/core/ [QSA,L]
+RewriteRule ^(.*)$ ../site-default/$1 [QSA,L]

--- a/README.md
+++ b/README.md
@@ -1,9 +1,27 @@
-Welcome to Core installation.
+## Installing PHP-Core
+This guide will show you how to get startet with a clean installation of the PHP-Core and a default site project.
+It assumes that no other projects are previously installed on your webserver.
 
-1. Add core folder (with lib folder and all "corestuff") to your www folder (where webroot is).
-2. Add .htaccess file to your www folder (where webroot is), that looks like this:
+If you already have the core and a site installed, and wish to add another site,
+we recommend that you follow the php-site installation guide instead: https://github.com/Dalisra/php-site
 
-    ```PHP
+#### 1. Adding the core folder
+Clone/Install the php-core project into a folder named "core" in your webserver root.
+For example in a Wamp environment on Windows, this would be "C:\wamp\www", "/var/www" in Lamp on Linux etc.
+
+This folder holds all the core framework files, db, bootstrap, config-files and so on.
+
+_Optional:_
+You can also give the core folder a name of your choosing, and use symlinks to get the same behaviour, though this can produce some issues.
+See _Symlinking the core and site folders_ in the _Additional guides_ section.
+
+#### 2. Adding .htaccess file at webserver root
+_As for now this guide assumes you are working with an apache web server, and thus uses .htaccess and Apache's Rewrite module.
+How to do rewriting with other web-servers might be documented later._
+
+Go to your webservers root folder, and add a new file called ".htaccess".
+Then open the file, paste the following content and save the file.
+
     #php_flag display_startup_errors on
     #php_flag display_errors on
     #php_flag html_errors on
@@ -14,26 +32,106 @@ Welcome to Core installation.
 
     #Options +FollowSymLinks -MultiViews -indexes
     RewriteEngine on
-    RewriteRule ^$ default/webroot/ [L]
-    RewriteRule ^(.*)$ default/webroot/$1 [L]
-    ```
+    RewriteRule ^$ site-default/webroot/ [L]
+    RewriteRule ^(.*)$ site-default/webroot/$1 [L]
 
-3a. Add a default site folder named as your client name (with default site files).
+#### 3. Adding the site folder
+Clone/Install the php-site project into a folder named "site-default" (ref. the .htaccess file you just added in step 2. ) in your webserver root.
 
-3b. If you added a folder that is NOT named "default" you will have to create a symlink to the other folder that you created.
-    Make sure you stand in your www folder (where webroot is) and run this command:
-    ln -s [yourfolder] default
-    For windows bruk mklink kommando.
+The php-site project: https://github.com/Dalisra/php-site
 
-4. Create empty "logs" folder in your www folder (where webroot is).
+This folder holds all the site specific files and folders. I.e. some default templates and controllers for you to use.
+It also comes prepackaged with bootstrap, font-awesome, and jQuery
 
-5. Make folder core/lib/Smarty/templates_c writable: chmod 777 [path] -R
-    * Not needed for windows.
+_Optional:_
+You can also give the site folder a name of your choosing, and use symlinks to get the same behaviour, though this can produce some issues.
+See _Symlinking the core and site folders_ in the _Additional guides_ section.
 
-6. Make folder core/lib/Smarty/cache writable: chmod 777 [path] -R
-    * Not needed for windows.
+#### 4. Create log folders
+PHP-Core uses the log4php library for logging, and will put log files in the "logs" folder of your webserver root.
+This may not be necessary on all operating systems, but it is good practice to make sure that you have the folder installed.
 
-99. Enjoy your site!
+The folder should be named "logs" in lowercase.
 
-100. [Optional] Create more default site folders and change between them by changing what symlink is linking to.
-    Or you can change .htaccess file that you created to support several sites.
+See _The complete directory structure_ for referencing.
+
+#### 5. Make Smarty folders writable
+This should just be necessary if you are on a Unix based system. Windows users, disregard this.
+
+Open your preferred Terminal app, go to your webserver root and run these commands:
+
+    chmod 777 core/lib/Smarty/templates_c -R
+    chmod 777 core/lib/Smarty/cache -R
+
+#### 6. Enjoy your site!
+Also, be sure to check out [the php-site project](https://github.com/Dalisra/php-site) and install lots of sites on the same webserver using the same core and **be awesome!**
+
+
+## Additional guides
+### Symlinking the core and site folders
+If you added a folder that is NOT named "site-default", you will have to create a symlink to the other folder that you created.
+Make sure you stand in your www folder (where webroot is) and run the following command.
+
+_NB! Linked folders is not compliant with all web servers, and proper function cannot be guaranteed if using this method._
+
+On Linux:
+
+    ln -s [your_folder_name] site-default
+
+On Windows:
+
+    mklink /D site-default [your_folder_name]
+
+#### The complete directory structure
+
+    \some\path\to\your\www\
+    ├───core
+    │   ├───config
+    │   ├───controllers
+    │   ├───lib
+    │   │   ├───log4php
+    │   │   │   └───2.3.0
+    │   │   │       ├───appenders
+    │   │   │       ├───configurators
+    │   │   │       ├───filters
+    │   │   │       ├───helpers
+    │   │   │       ├───layouts
+    │   │   │       ├───pattern
+    │   │   │       ├───renderers
+    │   │   │       └───xml
+    │   │   └───Smarty
+    │   │       ├───cache
+    │   │       ├───config
+    │   │       ├───plugins
+    │   │       ├───Smarty-3.1.14
+    │   │       │   ├───plugins
+    │   │       │   └───sysplugins
+    │   │       ├───Smarty-3.1.29
+    │   │       │   ├───plugins
+    │   │       │   └───sysplugins
+    │   │       └───templates_c
+    │   ├───models
+    │   ├───tests
+    │   └───views
+    │       ├───admin
+    │       └───error_pages
+    └───site-default
+    │   ├───config
+    │   ├───controllers
+    │   ├───views
+    │   │   ├───components
+    │   │   ├───error_pages
+    │   │   ├───layouts
+    │   │   └───pages
+    │   └───webroot
+    │      ├───bootstrap-3.3.6
+    │      │   ├───css
+    │      │   ├───fonts
+    │      │   └───js
+    │      ├───css
+    │      ├───font-awesome-4.5.0
+    │      │   ├───css
+    │      │   └───fonts
+    │      ├───jquery-1.12.1
+    │      └───js
+    ├───logs

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-## Installing PHP-Core
-This guide will show you how to get startet with a clean installation of the PHP-Core and a default site project.
-It assumes that no other projects are previously installed on your webserver.
+# Installing PHP-Core
+This guide will show you how to get started with a clean installation of the PHP-Core and a default site project.
+It assumes that no other projects are previously installed on your web server.
 
 If you already have the core and a site installed, and wish to add another site,
 we recommend that you follow the php-site installation guide instead: https://github.com/Dalisra/php-site
 
-#### 1. Adding the core folder
-Clone/Install the php-core project into a folder named "core" in your webserver root.
-For example in a Wamp environment on Windows, this would be "C:\wamp\www", "/var/www" in Lamp on Linux etc.
+## 1. Adding the core folder
+Clone/Install the php-core project into a folder named "core" in your web server root.
+For example in a Wamp environment on Windows, this would be "C:\wamp\www\core", "/var/www/core" in Lamp on Linux etc.
 
 This folder holds all the core framework files, db, bootstrap, config-files and so on.
 
@@ -15,7 +15,7 @@ _Optional:_
 You can also give the core folder a name of your choosing, and use symlinks to get the same behaviour, though this can produce some issues.
 See _Symlinking the core and site folders_ in the _Additional guides_ section.
 
-#### 2. Adding .htaccess file at webserver root
+## 2. Adding .htaccess file at webserver root
 _As for now this guide assumes you are working with an apache web server, and thus uses .htaccess and Apache's Rewrite module.
 How to do rewriting with other web-servers might be documented later._
 
@@ -35,7 +35,7 @@ Then open the file, paste the following content and save the file.
     RewriteRule ^$ site-default/webroot/ [L]
     RewriteRule ^(.*)$ site-default/webroot/$1 [L]
 
-#### 3. Adding the site folder
+## 3. Adding the site folder
 Clone/Install the php-site project into a folder named "site-default" (ref. the .htaccess file you just added in step 2. ) in your webserver root.
 
 The php-site project: https://github.com/Dalisra/php-site
@@ -47,7 +47,7 @@ _Optional:_
 You can also give the site folder a name of your choosing, and use symlinks to get the same behaviour, though this can produce some issues.
 See _Symlinking the core and site folders_ in the _Additional guides_ section.
 
-#### 4. Create log folder
+## 4. Create log folder
 PHP-Core uses the log4php library for logging, and will put log files in the "logs" folder of your webserver root.
 This may not be necessary on all operating systems, but it is good practice to make sure that you have the folder installed.
 
@@ -55,7 +55,7 @@ The folder should be named "logs" in lowercase.
 
 See _The complete directory structure_ for referencing.
 
-#### 5. Make Smarty folders writable
+## 5. Make Smarty folders writable
 This should just be necessary if you are on a Unix based system. Windows users, disregard this.
 
 Open your preferred Terminal app, go to your webserver root and run these commands:
@@ -63,12 +63,12 @@ Open your preferred Terminal app, go to your webserver root and run these comman
     chmod 777 core/lib/Smarty/templates_c -R
     chmod 777 core/lib/Smarty/cache -R
 
-#### 6. Enjoy your site!
+## 6. Enjoy your site!
 Also, be sure to check out [the php-site project](https://github.com/Dalisra/php-site) and install lots of sites on the same webserver using the same core and **be awesome!**
 
 
-## Additional guides
-### Symlinking the core and site folders
+# Additional guides
+## Symlinking the core and site folders
 If you added a folder that is NOT named "site-default", you will have to create a symlink to the other folder that you created.
 Make sure you stand in your www folder (where webroot is) and run the following command.
 
@@ -76,13 +76,16 @@ _NB! Linked folders is not compliant with all web servers, and proper function c
 
 On Linux:
 
-    ln -s [your_folder_name] site-default
+    ln -s [your_site_folder] site-default
+    ln -s [your_core_folder] core
 
 On Windows:
 
-    mklink /D site-default [your_folder_name]
+    mklink /D site-default [your_site_folder]
+    mklink /D core [your_core_folder]
 
-### The complete directory structure
+## The complete directory structure
+The directory tree below shows the complete directory strucure, with logs folder and site-default installed.
 
     \some\path\to\your\www\
     ├───core

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ On Windows:
 
     mklink /D site-default [your_folder_name]
 
-#### The complete directory structure
+### The complete directory structure
 
     \some\path\to\your\www\
     ├───core

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ _Optional:_
 You can also give the site folder a name of your choosing, and use symlinks to get the same behaviour, though this can produce some issues.
 See _Symlinking the core and site folders_ in the _Additional guides_ section.
 
-#### 4. Create log folders
+#### 4. Create log folder
 PHP-Core uses the log4php library for logging, and will put log files in the "logs" folder of your webserver root.
 This may not be necessary on all operating systems, but it is good practice to make sure that you have the folder installed.
 


### PR DESCRIPTION
Renamed references in .htaccess rewrites to php-site default location. New reference should be site-default/...

Also did a major update on the readme file due to this. Will make a corresponding update to the php-site project.
